### PR TITLE
1.1 Update

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Version Changelog
 
 ## `1.1`
-- Added functions `add_custom_item_to_arena` and `enable_arena_customization_settings` to add custom items to arena easily, with settings through ImGUI
+- Added functions `add_custom_item_to_arena`, `enable_arena_customization_settings` and `draw_custom_arena_item_settings` to add custom items to arena easily, with settings through ImGUI
 - Updated `new_custom_gun` to use `pre_trigger_action`, making other entities able to use the weapon
 - Fixed bug on waddler levels
 - Fixed some issues with powerups on death with ankh

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,15 @@
 # Version Changelog
 
+## `1.1`
+- Added functions `add_custom_item_to_arena` and `enable_arena_customization_settings` to add custom items to arena easily, with settings through ImGUI
+- Updated `new_custom_gun` to use `pre_trigger_action`, making other entities able to use the weapon
+- Fixed bug on waddler levels
+- Fixed some issues with powerups on death with ankh
+- Fixed an issue with the pickup example
+- Fixed issue when using instant restart while holding a custom item
+- Lil bomber now only spawns big bombs when having powerpack as backitem
+- Note: This update should be fully compatible with previous versions
+
 ## `1.0b`
 - Changed `ON.LOADING` callback to `ON.PRE_LOAD_SCREEN`, custom entities shouldn't be lost on transition due to frame drops
 - Warping to another level (no transition) now preserves the custom entities

--- a/custom_entities.lua
+++ b/custom_entities.lua
@@ -1,6 +1,6 @@
 meta = {
     name = "Custom-Entities-Library",
-    version = "1.0b",
+    version = "1.1",
     author = "Estebanfer",
     description = "A library for creating custom entities"
 }

--- a/custom_entities.lua
+++ b/custom_entities.lua
@@ -4,7 +4,6 @@ meta = {
     author = "Estebanfer",
     description = "A library for creating custom entities"
 }
---TODO: change backitem carry type to CARRY_TYPE.BACK
 
 local FLAGS_BIT = { --https://github.com/Mr-Auto/spelunky2-lua-libs/blob/main/libraries/flags/flags.lua
 0x1,

--- a/documentation.md
+++ b/documentation.md
@@ -140,6 +140,24 @@ Spawn a FX_PICKUPEFFECT on player_uid, and set its texture and animation_frame. 
 
 I couldn't make the normal pickup to be purchasable without it giving the base pickup, so this spawns an entity that acts like a pickup, and manually handles buying it.
 
+### `nil add_custom_item_to_arena(int custom_ent_id)`
+
+Add settings and chances for the custom item to be on arena.
+
+Make sure to have used `add_custom_entity_info` so the settings show the entity name
+
+For powerups, use the powerup type instead of the pickup item
+
+See also `enable_arena_customization_settings` or `draw_custom_arena_item_settings`
+
+### `nil draw_custom_arena_item_settings(GuiDrawContext draw_ctx)`
+
+Draw settings for custom arena items. `enable_arena_customization_settings` might be preferable. Not recommended if importing the library with `import` since it can also show items from another mods
+
+### `nil enable_arena_customization_settings()`
+
+Register an option callback for custom items in arena. Recommended if importing the library with `import`. See also `draw_custom_arena_item_settings`
+
 ## Enums
 
 ### **CHANCE**

--- a/examples/Grapple_gun/grapple_gun.lua
+++ b/examples/Grapple_gun/grapple_gun.lua
@@ -244,6 +244,8 @@ celib.add_custom_shop_chance(grapple_id, celib.CHANCE.LOW, {celib.SHOP_TYPE.SPEC
 celib.add_custom_container_chance(grapple_id, celib.CHANCE.LOW, {ENT_TYPE.ITEM_CRATE, ENT_TYPE.ITEM_PRESENT})
 celib.add_custom_entity_crust_chance(grapple_id, 0.05)
 celib.define_custom_entity_tilecode(grapple_id, "grapple_gun", true)
+celib.add_custom_item_to_arena(grapple_id)
+celib.enable_arena_customization_settings()
 
 celib.init()
 

--- a/examples/ParachutePack.lua
+++ b/examples/ParachutePack.lua
@@ -60,6 +60,8 @@ c_ent_lib.add_custom_container_chance(parachute_back, c_ent_lib.CHANCE.LOW, {ENT
 c_ent_lib.add_custom_entity_crust_chance(parachute_back, 0.05)
 c_ent_lib.define_custom_entity_tilecode(parachute_back, "parachute_pack", true)
 
+c_ent_lib.add_custom_item_to_arena(parachute_back)
+c_ent_lib.enable_arena_customization_settings()
 
 register_option_button('parachutepack_spawn', 'spawn ParachutePack', '', function()
     local x, y, l = get_position(players[1].uid)

--- a/examples/lil_bomber_item_example/lil_bomber.lua
+++ b/examples/lil_bomber_item_example/lil_bomber.lua
@@ -48,7 +48,7 @@ local function mycustom_shoot(weapon)
     bomb.last_owner_uid = weapon.overlay.uid
 end
 
-local c_gun = c_ent_lib.new_custom_gun2(mycustom_set, mycustom_update, mycustom_shoot, 60, 0, 0, ENT_TYPE.ITEM_FREEZERAY, true)
+local c_gun = c_ent_lib.new_custom_gun(mycustom_set, mycustom_update, mycustom_shoot, 60, 0.2, 0.05, ENT_TYPE.ITEM_FREEZERAY)
 c_ent_lib.add_custom_entity_info(c_gun, "Lil Bomber", lil_bomber_texture_id, 0, 15000, 1500)
 
 c_ent_lib.add_custom_shop_chance(c_gun, c_ent_lib.CHANCE.LOW, {c_ent_lib.SHOP_TYPE.TUN, c_ent_lib.SHOP_TYPE.CAVEMAN}, true)

--- a/examples/lil_bomber_item_example/lil_bomber.lua
+++ b/examples/lil_bomber_item_example/lil_bomber.lua
@@ -38,7 +38,7 @@ local function mycustom_shoot(weapon)
     local bomb = get_entity(spawn(ENT_TYPE.ITEM_BOMB, x+0.2*dir, y, l, 0.25*dir, 0.075))
     bomb_spawn_sound:play()
     local backitem_uid = weapon.overlay:worn_backitem()
-    if backitem_uid ~= -1 then
+    if backitem_uid ~= -1 and get_entity_type(backitem_uid) == ENT_TYPE.ITEM_POWERPACK then
         bomb.width = 1.875
         bomb.height = 1.875
         bomb.scale_hor = 1.875
@@ -50,6 +50,8 @@ end
 
 local c_gun = c_ent_lib.new_custom_gun(mycustom_set, mycustom_update, mycustom_shoot, 60, 0.2, 0.05, ENT_TYPE.ITEM_FREEZERAY)
 c_ent_lib.add_custom_entity_info(c_gun, "Lil Bomber", lil_bomber_texture_id, 0, 15000, 1500)
+c_ent_lib.add_custom_item_to_arena(c_gun)
+c_ent_lib.enable_arena_customization_settings()
 
 c_ent_lib.add_custom_shop_chance(c_gun, c_ent_lib.CHANCE.LOW, {c_ent_lib.SHOP_TYPE.TUN, c_ent_lib.SHOP_TYPE.CAVEMAN}, true)
 c_ent_lib.add_custom_shop_chance(c_gun, c_ent_lib.CHANCE.LOWER, {c_ent_lib.SHOP_TYPE.WEAPON_SHOP, c_ent_lib.SHOP_TYPE.SPECIALTY_SHOP, c_ent_lib.SHOP_TYPE.DICESHOP, c_ent_lib.SHOP_TYPE.TUSKDICESHOP}, true)

--- a/examples/pickup.lua
+++ b/examples/pickup.lua
@@ -86,9 +86,12 @@ celib.add_custom_container_chance(pickup_id, celib.CHANCE.COMMON, celib.ALL_CONT
 
 celib.add_custom_shop_chance(purchasable_pickup_id, celib.CHANCE.COMMON, celib.ALL_SHOPS, true)
 
+celib.add_custom_item_to_arena(powerup_id)
+celib.enable_arena_customization_settings()
+
 celib.init()
 
-set_callback(function()
+register_option_button('rainbower_spawn', 'spawn rainbower', '', function()
     local x, y, l = get_position(players[1].uid)
     celib.spawn_custom_entity(pickup_id, x, y, l, 0, 0)
-end, ON.START)
+end)

--- a/examples/pickup.lua
+++ b/examples/pickup.lua
@@ -78,7 +78,7 @@ local powerup_id = celib.new_custom_powerup(powerup_set_func, powerup_update_fun
 
 pickup_id = celib.new_custom_pickup(pickup_set_func, pickup_update_func, pickup_picked_func, powerup_id, ENT_TYPE.ITEM_PICKUP_COMPASS)
 celib.add_custom_entity_info(pickup_id, "Rainbower", TEXTURE.DATA_TEXTURES_FX_SMALL3_0, 8, 1500, 500)
-celib.set_powerup_drop(pickup_id)
+celib.set_powerup_drop(powerup_id, pickup_id)
 
 local purchasable_pickup_id = celib.new_custom_purchasable_pickup(pickup_set_func, pickup_update_func, pickup_id)
 

--- a/examples/playerghost_pickup.lua
+++ b/examples/playerghost_pickup.lua
@@ -242,8 +242,6 @@ celib.set_powerup_drop(powerup_id, pickup_id)
 celib.add_custom_entity_info(pickup_id, "Spectral Mirror", mirror_texture_id, 0, 15000, 1500)
 celib.add_custom_entity_crust_chance(pickup_id, 0.025)
 celib.define_custom_entity_tilecode(pickup_id, "spectral_mirror", true)
-celib.add_custom_item_to_arena(powerup_id)
-celib.enable_arena_customization_settings()
 
 local purchasable_pickup_id = celib.new_custom_purchasable_pickup(pickup_set_func, pickup_update_func, pickup_id)
 

--- a/examples/playerghost_pickup.lua
+++ b/examples/playerghost_pickup.lua
@@ -242,6 +242,8 @@ celib.set_powerup_drop(powerup_id, pickup_id)
 celib.add_custom_entity_info(pickup_id, "Spectral Mirror", mirror_texture_id, 0, 15000, 1500)
 celib.add_custom_entity_crust_chance(pickup_id, 0.025)
 celib.define_custom_entity_tilecode(pickup_id, "spectral_mirror", true)
+celib.add_custom_item_to_arena(powerup_id)
+celib.enable_arena_customization_settings()
 
 local purchasable_pickup_id = celib.new_custom_purchasable_pickup(pickup_set_func, pickup_update_func, pickup_id)
 


### PR DESCRIPTION
## `1.1`
- Added functions `add_custom_item_to_arena` and `enable_arena_customization_settings` to add custom items to arena easily, with settings through ImGUI
- Updated `new_custom_gun` to use `pre_trigger_action`, making other entities able to use the weapon
- Fixed bug on waddler levels
- Fixed some issues with powerups on death with ankh
- Fixed an issue with the pickup example
- Fixed issue when using instant restart while holding a custom item
- Lil bomber now only spawns big bombs when having powerpack as backitem
- Note: This update should be fully compatible with previous versions